### PR TITLE
Adding support for webhooks

### DIFF
--- a/api/v1alpha1/pipeline_stage_types.go
+++ b/api/v1alpha1/pipeline_stage_types.go
@@ -323,7 +323,6 @@ type Jitter struct {
 type StatusUrlResolution string
 
 // Webhook represents a webhook stage in Spinnaker.
-// NOTE: I suspect this only supports `helm2` style deployments right now.
 // NOTE: notifications currently not supported for this stage.
 type Webhook struct {
 	// +optional
@@ -351,7 +350,6 @@ type Webhook struct {
 	//+optional
 	CustomHeaders string `json:"customHeaders,omitempty"`
 	WebhookMethod string `json:"method,omitempty"`
-	Name string `json:"name,omitempty"`
 	//+optional
 	Payload string `json:"payload,omitempty"`
 	//+optional
@@ -368,7 +366,6 @@ type Webhook struct {
 	SuccessStatuses string `json:"successStatuses,omitempty"`
 	//+optional
 	TerminalStatuses string `json:"terminalStatuses,omitempty"`
-	Type string `json:"type,omitempty"`
 	Url string `json:"url,omitempty"`
 	//+optional
 	WaitBeforeMonitor string `json:"waitBeforeMonitor,omitempty"`
@@ -471,8 +468,7 @@ func (su StageUnion) ToSpinnakerStage() (map[string]interface{}, error) {
 }
 
 func rewriteStringValueFromMapToMapInterface(field string, mapified map[string]interface{})  error {
-	fieldString, ok := mapified[field].(string)
-	if ok {
+	if fieldString, ok := mapified[field].(string); ok {
 		payloadMap,err := stringToMapInterface(fieldString)
 		if err != nil {
 			return err
@@ -482,7 +478,7 @@ func rewriteStringValueFromMapToMapInterface(field string, mapified map[string]i
 	return nil
 }
 
-func stringToMapInterface(stringToConvert string) (interface{}, error) {
+func stringToMapInterface(stringToConvert string) (map[string]interface{}, error) {
 	valuesMap := make(map[string]interface{})
 	err := yaml.Unmarshal([]byte(stringToConvert), valuesMap)
 	return valuesMap, err

--- a/config/crd/bases/pacrd.armory.spinnaker.io_pipelines.yaml
+++ b/config/crd/bases/pacrd.armory.spinnaker.io_pipelines.yaml
@@ -639,8 +639,6 @@ spec:
                         type: boolean
                       method:
                         type: string
-                      name:
-                        type: string
                       payload:
                         type: string
                       progressJsonPath:
@@ -713,8 +711,6 @@ spec:
                       successStatuses:
                         type: string
                       terminalStatuses:
-                        type: string
-                      type:
                         type: string
                       url:
                         type: string

--- a/config/samples/pipeline_jg.yaml
+++ b/config/samples/pipeline_jg.yaml
@@ -55,9 +55,7 @@ spec:
         customHeaders: |
           customheader: customvalue
           customheader2: customalue2
-        # "isNew": true,
         method: POST
-        name: Webhook stage name
         payload: |
           test: payloadtest
           statuscode: 200
@@ -69,7 +67,6 @@ spec:
         statusUrlJsonPath: http://test
         successStatuses: SUCCESS, OK
         terminalStatuses: TERMINAL, FINISHED
-        type: webhook
         url: webhook url
         waitBeforeMonitor: "1"
         waitForCompletion: true


### PR DESCRIPTION
This changes are adding support for webhooks and pacrd, making this changes I found a bug:

There's a field called: **Signal on cancellation** that is not getting parsed in the ui (when you check it doesn't register anything), so everytime even if you enable it from the ui appears unchecked when you refresh.