### PR TITLE
fix(pacrd): overrides in bake manifest should be empty even if isn't needed

### DIFF
--- a/api/v1alpha1/pipeline_stage_types.go
+++ b/api/v1alpha1/pipeline_stage_types.go
@@ -375,6 +375,11 @@ func (su StageUnion) ToSpinnakerStage() (map[string]interface{}, error) {
 		s.TagName = "json"
 		mapified = s.Map()
 
+		//When overrides is not present we need to sent it anyways, otherwise rosco fails
+		if overrideval, ok := mapified["overrides"]; !ok || overrideval == nil {
+			mapified["overrides"] = map[string]string{}
+		}
+
 		var mapifiedArtifacts []map[string]interface{}
 		for _, a := range crd.ExpectedArtifacts {
 			artifact, err := a.MarshallToMap()


### PR DESCRIPTION
Now overrides value is sent even if you don't use it for bake manifest, final requests evidence:
```            "name": "Bake PaCRD Manifest",
            "namespace": "ffreire",
            "outputName": "pacrd-dev-manifest",
            "overrides": {},
            "refId": "1",
            "requisiteStageRefIds": null,