### PR TITLE
Upgrade pacrd CRDs from v1beta1 to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 RELEASE ?= ""  # Must be set at runtime
 IMG ?= armory/pacrd:${RELEASE}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 DOCS_PROJECT ?= ~/armory/documentation
 OS=$(shell go env GOOS)
 ARCH=$(shell go env GOARCH)

--- a/config/crd/bases/pacrd.armory.spinnaker.io_applications.yaml
+++ b/config/crd/bases/pacrd.armory.spinnaker.io_applications.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,18 +8,6 @@ metadata:
   creationTimestamp: null
   name: applications.pacrd.armory.spinnaker.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status
-    name: status
-    type: string
-  - JSONPath: .status.lastConfigured
-    description: Last Configured
-    name: lastConfigured
-    type: date
-  - JSONPath: .status.url
-    name: URL
-    type: string
   group: pacrd.armory.spinnaker.io
   names:
     kind: Application
@@ -29,117 +17,128 @@ spec:
     - app
     singular: application
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Application is the Schema for the applications API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ApplicationSpec defines the desired state of Application
-          properties:
-            dataSources:
-              description: DataSources optionally enable and disable elements of the
-                Spinnaker Application UI.
-              properties:
-                disabled:
-                  description: Disabled is the list of explicitly disabled UI elements.
-                  items:
-                    description: 'DataSource is a tab in the Spinnaker UI representing
-                      a kind of managed resource. Allowed values include: serverGroups,executions,loadBalancers,securityGroups.'
-                    enum:
-                    - serverGroups
-                    - executions
-                    - loadBalancers
-                    - securityGroups
-                    type: string
-                  type: array
-                enabled:
-                  description: Enabled is the list of explicitly enabled UI elements.
-                  items:
-                    description: 'DataSource is a tab in the Spinnaker UI representing
-                      a kind of managed resource. Allowed values include: serverGroups,executions,loadBalancers,securityGroups.'
-                    enum:
-                    - serverGroups
-                    - executions
-                    - loadBalancers
-                    - securityGroups
-                    type: string
-                  type: array
-              type: object
-            description:
-              description: Description explains the purpose of this application.
-              type: string
-            email:
-              description: Email points to the e-mail user or list that owns this
-                application.
-              type: string
-            permissions:
-              description: Permissions maps actions inside Spinnaker to authenticated
-                roles that can take them.
-              properties:
-                EXECUTE:
-                  description: Execute grants the defined roles the ability to execute
-                    an application's pipelines.
-                  items:
-                    type: string
-                  type: array
-                READ:
-                  description: Read grants the defined roles the ability to read an
-                    application and its pipelines.
-                  items:
-                    type: string
-                  type: array
-                WRITE:
-                  description: Write grants the defined roles the ability to modify
-                    an application and its pipelines.
-                  items:
-                    type: string
-                  type: array
-              type: object
-          type: object
-        status:
-          description: ApplicationStatus defines the observed state of Application
-          properties:
-            lastConfigured:
-              description: LastConfigured represents the last time the operator updated
-                this application in Spinnaker.
-              format: date-time
-              type: string
-            phase:
-              description: Phase represents the current status of this application.
-              enum:
-              - ErrorNotFound
-              - Creating
-              - ErrorFailedToCreate
-              - Created
-              - Deleting
-              - ErrorDeletingApplication
-              - Updated
-              - ErrorUpdatingApplication
-              type: string
-            url:
-              description: Url represents the URL of the configured Spinnaker cluster.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.phase
+      name: status
+      type: string
+    - description: Last Configured
+      jsonPath: .status.lastConfigured
+      name: lastConfigured
+      type: date
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is the Schema for the applications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSpec defines the desired state of Application
+            properties:
+              dataSources:
+                description: DataSources optionally enable and disable elements of
+                  the Spinnaker Application UI.
+                properties:
+                  disabled:
+                    description: Disabled is the list of explicitly disabled UI elements.
+                    items:
+                      description: 'DataSource is a tab in the Spinnaker UI representing
+                        a kind of managed resource. Allowed values include: serverGroups,executions,loadBalancers,securityGroups.'
+                      enum:
+                      - serverGroups
+                      - executions
+                      - loadBalancers
+                      - securityGroups
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled is the list of explicitly enabled UI elements.
+                    items:
+                      description: 'DataSource is a tab in the Spinnaker UI representing
+                        a kind of managed resource. Allowed values include: serverGroups,executions,loadBalancers,securityGroups.'
+                      enum:
+                      - serverGroups
+                      - executions
+                      - loadBalancers
+                      - securityGroups
+                      type: string
+                    type: array
+                type: object
+              description:
+                description: Description explains the purpose of this application.
+                type: string
+              email:
+                description: Email points to the e-mail user or list that owns this
+                  application.
+                type: string
+              permissions:
+                description: Permissions maps actions inside Spinnaker to authenticated
+                  roles that can take them.
+                properties:
+                  EXECUTE:
+                    description: Execute grants the defined roles the ability to execute
+                      an application's pipelines.
+                    items:
+                      type: string
+                    type: array
+                  READ:
+                    description: Read grants the defined roles the ability to read
+                      an application and its pipelines.
+                    items:
+                      type: string
+                    type: array
+                  WRITE:
+                    description: Write grants the defined roles the ability to modify
+                      an application and its pipelines.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ApplicationStatus defines the observed state of Application
+            properties:
+              lastConfigured:
+                description: LastConfigured represents the last time the operator
+                  updated this application in Spinnaker.
+                format: date-time
+                type: string
+              phase:
+                description: Phase represents the current status of this application.
+                enum:
+                - ErrorNotFound
+                - Creating
+                - ErrorFailedToCreate
+                - Created
+                - Deleting
+                - ErrorDeletingApplication
+                - Updated
+                - ErrorUpdatingApplication
+                type: string
+              url:
+                description: Url represents the URL of the configured Spinnaker cluster.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/pacrd.armory.spinnaker.io_pipelines.yaml
+++ b/config/crd/bases/pacrd.armory.spinnaker.io_pipelines.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,18 +8,6 @@ metadata:
   creationTimestamp: null
   name: pipelines.pacrd.armory.spinnaker.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Status
-    name: status
-    type: string
-  - JSONPath: .status.lastConfigured
-    description: Last Configured
-    name: lastConfigured
-    type: date
-  - JSONPath: .status.url
-    name: URL
-    type: string
   group: pacrd.armory.spinnaker.io
   names:
     kind: Pipeline
@@ -29,189 +17,200 @@ spec:
     - pipe
     singular: pipeline
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Pipeline is the Schema for the pipelines API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PipelineSpec defines the desired state of Pipeline
-          properties:
-            allowParallelExecutions:
-              description: AllowParallelExecutions TODO
-              type: boolean
-            application:
-              description: Application is a reference to the application that owns
-                this pipeline.
-              type: string
-            description:
-              description: Description tells the user what this pipeline is for.
-              type: string
-            executionEngine:
-              description: ExecutionEngine TODO
-              type: string
-            expectedArtifacts:
-              items:
-                description: Artifact is an object that references an external resource.
-                  It could be a Docker container, file in source control, AMI, or
-                  binary blob in S3, etc.
-                properties:
-                  defaultArtifact:
-                    description: If your artifact either wasn't supplied from a trigger,
-                      or it wasn't found in a prior execution, the artifact specified
-                      here will end up in your pipeline's execution context.
-                    properties:
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.phase
+      name: status
+      type: string
+    - description: Last Configured
+      jsonPath: .status.lastConfigured
+      name: lastConfigured
+      type: date
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pipeline is the Schema for the pipelines API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PipelineSpec defines the desired state of Pipeline
+            properties:
+              allowParallelExecutions:
+                description: AllowParallelExecutions TODO
+                type: boolean
+              application:
+                description: Application is a reference to the application that owns
+                  this pipeline.
+                type: string
+              description:
+                description: Description tells the user what this pipeline is for.
+                type: string
+              executionEngine:
+                description: ExecutionEngine TODO
+                type: string
+              expectedArtifacts:
+                items:
+                  description: Artifact is an object that references an external resource.
+                    It could be a Docker container, file in source control, AMI, or
+                    binary blob in S3, etc.
+                  properties:
+                    defaultArtifact:
+                      description: If your artifact either wasn't supplied from a
+                        trigger, or it wasn't found in a prior execution, the artifact
+                        specified here will end up in your pipeline's execution context.
                       properties:
-                        type: object
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  displayName:
-                    description: DisplayName tells Spinnaker how to render this artifact
-                      in the UI.
-                    type: string
-                  id:
-                    description: ID is a unique identifier for this artifact. IDs
-                      must only be unique for the pipeline they are declared in.
-                    type: string
-                  matchArtifact:
-                    description: "This specifies which fields in your incoming artifact
-                      to match against. Every field that you supply will be used to
-                      match against all incoming artifacts. If all specified fields
-                      match, the incoming artifact is bound to your pipeline context.
-                      \n See the [reference](https://www.spinnaker.io/reference/artifacts/in-pipelines/#expected-artifacts)
-                      for more information."
-                    properties:
-                      properties:
-                        type: object
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  useDefaultArtifact:
-                    description: If true, requires DefaultArtifact to be defined with
-                      a fallback artifact to use.
-                    type: boolean
-                  usePriorArtifact:
-                    description: "Attempt to match against an artifact in the prior
-                      pipeline execution's context. \n See the [reference](https://www.spinnaker.io/reference/artifacts/in-pipelines)
-                      for more information."
-                    type: boolean
-                required:
-                - displayName
-                - id
-                type: object
-              type: array
-            keepWaitingPipelines:
-              description: KeepWaitingPipelines TODO
-              type: boolean
-            limitConccurent:
-              description: LimitConcurrent TODO
-              type: boolean
-            parameterConfig:
-              items:
-                properties:
-                  default:
-                    type: string
-                  description:
-                    type: string
-                  hasOptions:
-                    type: boolean
-                  label:
-                    type: string
-                  name:
-                    type: string
-                  options:
-                    items:
-                      properties:
-                        value:
+                        properties:
+                          type: object
+                        type:
                           type: string
                       required:
-                      - value
+                      - type
                       type: object
-                    type: array
-                  pinned:
-                    type: boolean
+                    displayName:
+                      description: DisplayName tells Spinnaker how to render this
+                        artifact in the UI.
+                      type: string
+                    id:
+                      description: ID is a unique identifier for this artifact. IDs
+                        must only be unique for the pipeline they are declared in.
+                      type: string
+                    matchArtifact:
+                      description: "This specifies which fields in your incoming artifact
+                        to match against. Every field that you supply will be used
+                        to match against all incoming artifacts. If all specified
+                        fields match, the incoming artifact is bound to your pipeline
+                        context. \n See the [reference](https://www.spinnaker.io/reference/artifacts/in-pipelines/#expected-artifacts)
+                        for more information."
+                      properties:
+                        properties:
+                          type: object
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    useDefaultArtifact:
+                      description: If true, requires DefaultArtifact to be defined
+                        with a fallback artifact to use.
+                      type: boolean
+                    usePriorArtifact:
+                      description: "Attempt to match against an artifact in the prior
+                        pipeline execution's context. \n See the [reference](https://www.spinnaker.io/reference/artifacts/in-pipelines)
+                        for more information."
+                      type: boolean
                   required:
-                    type: boolean
-                required:
-                - name
-                type: object
-              type: array
-            stages:
-              description: Stages TODO
-              items:
-                properties:
+                  - displayName
+                  - id
+                  type: object
+                type: array
+              keepWaitingPipelines:
+                description: KeepWaitingPipelines TODO
+                type: boolean
+              limitConccurent:
+                description: LimitConcurrent TODO
+                type: boolean
+              parameterConfig:
+                items:
                   properties:
-                    type: object
-                  type:
-                    type: string
-                type: object
-              type: array
-            triggers:
-              description: Triggers represent the ways in which
-              items:
-                properties:
+                    default:
+                      type: string
+                    description:
+                      type: string
+                    hasOptions:
+                      type: boolean
+                    label:
+                      type: string
+                    name:
+                      type: string
+                    options:
+                      items:
+                        properties:
+                          value:
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      type: array
+                    pinned:
+                      type: boolean
+                    required:
+                      type: boolean
+                  required:
+                  - name
+                  type: object
+                type: array
+              stages:
+                description: Stages TODO
+                items:
                   properties:
-                    type: object
-                  type:
-                    type: string
-                required:
-                - type
-                type: object
-              type: array
-          required:
-          - stages
-          type: object
-        status:
-          description: PipelineStatus defines the observed state of Pipeline
-          properties:
-            id:
-              description: ID represents the Spinnaker generated id for this pipeline
-              type: string
-            lastConfigured:
-              description: LastConfigured represents the last time the operator updated
-                this pipeline in Spinnaker.
-              format: date-time
-              type: string
-            phase:
-              description: Phase is the current phase of pipeline reconciliation.
-              enum:
-              - ErrorNotFound
-              - Creating
-              - ErrorFailedToCreate
-              - Created
-              - Deleting
-              - ErrorDeletingPipeline
-              - Updated
-              - ErrorUpdatingPipeline
-              - PipelineValidationFailed
-              type: string
-            url:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                    properties:
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                type: array
+              triggers:
+                description: Triggers represent the ways in which
+                items:
+                  properties:
+                    properties:
+                      type: object
+                    type:
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+            required:
+            - stages
+            type: object
+          status:
+            description: PipelineStatus defines the observed state of Pipeline
+            properties:
+              id:
+                description: ID represents the Spinnaker generated id for this pipeline
+                type: string
+              lastConfigured:
+                description: LastConfigured represents the last time the operator
+                  updated this pipeline in Spinnaker.
+                format: date-time
+                type: string
+              phase:
+                description: Phase is the current phase of pipeline reconciliation.
+                enum:
+                - ErrorNotFound
+                - Creating
+                - ErrorFailedToCreate
+                - Created
+                - Deleting
+                - ErrorDeletingPipeline
+                - Updated
+                - ErrorUpdatingPipeline
+                - PipelineValidationFailed
+                type: string
+              url:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This PR upgrades pacrd CRDs from v1beta1 to v1 since v1beta1 will be deprecated in kubernetes 1.22